### PR TITLE
nixos: microcode-intel: 20220510 -> 20220809

### DIFF
--- a/pkgs/os-specific/linux/microcode/intel.nix
+++ b/pkgs/os-specific/linux/microcode/intel.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "microcode-intel";
-  version = "20220510";
+  version = "20220809";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "Intel-Linux-Processor-Microcode-Data-Files";
     rev = "microcode-${version}";
-    sha256 = "sha256-x+8qyC7YP7co/7qLhaAtjMtyeANaZJ/r41iFl1Mut+M=";
+    hash = "sha256-vcuLQHAGr5uRkGWWIwA2WXLJadVNxfcPgjmNS82Logg=";
   };
 
   nativeBuildInputs = [ iucode-tool libarchive ];


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/185828.
Will be removed (for a rebased version) when
https://github.com/NixOS/nixpkgs/pull/185850 makes it into a new
tag/release.

https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20220809
https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00657.html

Fixes: CVE-2022-21233
Signed-off-by: Patrick Uiterwijk <patrick@profian.com>