### PR TITLE
feat: remove nginx usage for steward configurable

### DIFF
--- a/nixos/modules/services/security/steward.nix
+++ b/nixos/modules/services/security/steward.nix
@@ -9,9 +9,6 @@ with lib; let
 
   defaultStore = "/var/lib/steward";
 
-  # TODO: Make FQDN configurable
-  fqdn = config.networking.fqdn;
-
   conf.toml = ''
     crt = "${cfg.certFile}"
     key = "${cfg.keyFile}"
@@ -53,23 +50,9 @@ in {
 
   config = mkIf cfg.enable (mkMerge [
     {
-      assertions = [
-        {
-          assertion = config.services.nginx.enable;
-          message = "Nginx service is not enabled";
-        }
-      ];
-
       environment.systemPackages = [
         cfg.package
       ];
-
-      services.nginx.virtualHosts.${fqdn} = {
-        enableACME = true;
-        forceSSL = true;
-        http2 = false;
-        locations."/".proxyPass = "http://localhost:3000";
-      };
 
       systemd.services.steward.after = [
         "network-online.target"


### PR DESCRIPTION
Steward will need to do its own TLS termination in the long run, so
having an nginx reverse proxy in front of that will not work.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>
