### PR TITLE
fix: swap around demo-fqdn and session-key

### DIFF
--- a/nixos/modules/services/web-apps/benefice.nix
+++ b/nixos/modules/services/web-apps/benefice.nix
@@ -51,11 +51,11 @@ with lib; let
     + optionalString (cfg.oidc.secretFile != null) ''
       oidc-secret = "${cfg.oidc.secretFile}"
     ''
-    + optionalString (cfg.sessionKey != null) ''
-      session-key = "${cfg.sessionKey}"
-    ''
     + optionalString (cfg.demoFqdn != null) ''
       demo-fqdn = "${cfg.demoFqdn}"
+    ''
+    + optionalString (cfg.sessionKey != null) ''
+      session-key = "${cfg.sessionKey}"
     '';
 
   configFile = pkgs.writeText "conf.toml" conf.toml;


### PR DESCRIPTION
For some reason, this order works, while the other fails.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>
